### PR TITLE
Support leading hyphens if no space immediately following

### DIFF
--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -240,9 +240,11 @@ func getType(line []byte) (typ, split int) {
 	}
 
 	if line[0] == '-' {
-		typ = typSequence
-		split = 1
-		return
+		if len(line) == 1 || line[1] == ' ' {
+			typ = typSequence
+			split = 1
+			return
+		}
 	}
 
 	typ = typScalar

--- a/yaml/parser_test.go
+++ b/yaml/parser_test.go
@@ -41,6 +41,18 @@ var parseTests = []struct {
 		Output: "key4 :val1\n",
 	},
 	{
+		Input:  "key5: -val1\n",
+		Output: "key5: -val1\n",
+	},
+	{
+		Input:  "key7: -1\n",
+		Output: "key7: -1\n",
+	},
+	{
+		Input:  "key8: -3.14\n",
+		Output: "key8: -3.14\n",
+	},
+	{
 		Input: "key: nest: val\n",
 		Output: "key:\n" +
 			"  nest: val\n",


### PR DESCRIPTION
Simple patch to allow parsing negative numbers and leading hyphen strings (such as command options/switches)
